### PR TITLE
don't omit empty lines of decrypted content

### DIFF
--- a/src/main/kotlin/de/timo_reymann/ansible_vault_integration/execution/action/AnsibleVaultAction.kt
+++ b/src/main/kotlin/de/timo_reymann/ansible_vault_integration/execution/action/AnsibleVaultAction.kt
@@ -56,8 +56,8 @@ abstract class AnsibleVaultAction(protected val project: Project, protected val 
                 override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
                     val stdoutLine = event.text.trim { it <= ' ' }
 
-                    // Empty line or line break
-                    if (stdoutLine == "" || stdoutLine.startsWith("WARNING:")) {
+                    // Omit warnings
+                    if (stdoutLine.startsWith("WARNING:")) {
                         return
                     }
 


### PR DESCRIPTION
Hey Timo,

the current implementation for decrypting vaulted files has - imho - a major flaw.

All empty lines will be completely omitted/removed from the content.
Which is totally unexpected and not the actual behaviour of `ansible-vault decrypt`.

For example:

If you encrypt a vars-file ...

```
my_var1:
   attribute1: test1
   attribute2: test2

my_var2:
   attribute1: test1
   attribute2: test2

another_var: test
```

... and decrypt it again, you will end up with this:

```
my_var1:
   attribute1: test1
   attribute2: test2
my_var2:
   attribute1: test1
   attribute2: test2
another_var: test
```

(Which syntactically may work but completely kills all "organizational formatting" :smile:.)

Would you please consider merging this PR?

Thank you very much!