### PR TITLE
implement multiple file support for context-menu; remove YAML-file re…

### DIFF
--- a/src/main/kotlin/de/timo_reymann/ansible_vault_integration/intention/menu/VaultFileMenuAction.kt
+++ b/src/main/kotlin/de/timo_reymann/ansible_vault_integration/intention/menu/VaultFileMenuAction.kt
@@ -1,62 +1,84 @@
 package de.timo_reymann.ansible_vault_integration.intention.menu
 
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.LangDataKeys
 import com.intellij.openapi.progress.ProgressManager
+import com.intellij.psi.PsiBinaryFile
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import de.timo_reymann.ansible_vault_integration.config.AnsibleConfigurationService
+import de.timo_reymann.ansible_vault_integration.config.VaultIdentity
 import de.timo_reymann.ansible_vault_integration.execution.AnsibleVaultTask
 import de.timo_reymann.ansible_vault_integration.intention.AnsibleVaultIdentityPopup
-import de.timo_reymann.ansible_vault_integration.runnable.AnsibleVaultRunnable
 import de.timo_reymann.ansible_vault_integration.runnable.DecryptFileAnsibleVaultRunnable
 import de.timo_reymann.ansible_vault_integration.runnable.EncryptFileAnsibleVaultRunnable
 
 open class VaultFileMenuAction : AnAction() {
+    private val progressManager: ProgressManager = ProgressManager.getInstance()
+
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
+        val psiManager = PsiManager.getInstance(project)
+        val vaultIdentities = AnsibleConfigurationService.getInstance(project).getAggregatedConfig().vaultIdentities
+
         e.getData(LangDataKeys.VIRTUAL_FILE_ARRAY)?.forEach {
-            val psiFile = PsiManager.getInstance(project).findFile(it) ?: return@forEach
-            val content = psiFile.text ?: return@forEach
-            val isVaulted = content.startsWith("\$ANSIBLE_VAULT")
-            val title = "${if (isVaulted) "Decrypt" else "Encrypt"} file(s) with ansible-vault"
+            val psiFile = psiManager.findFile(it) ?: return@forEach
 
-            if (isVaulted) {
-                runTask(psiFile, title, DecryptFileAnsibleVaultRunnable(psiFile.project, psiFile, content))
+            if (psiFile is PsiBinaryFile) {
+                Notifications.Bus.notify(Notification(
+                    VaultFileMenuAction::class.java.canonicalName,
+                    NOTIFICATION_ERROR_TITLE,
+                    NOTIFICATION_BINARIES_NOT_SUPPORTED,
+                    NotificationType.ERROR
+                ))
+
+                return@forEach
+            }
+
+            if (psiFile.text.isNullOrEmpty()) {
+                return@forEach
+            }
+
+            processFile(vaultIdentities, psiFile)
+        }
+    }
+
+    private fun processFile(vaultIdentities: List<VaultIdentity>?, psiFile: PsiFile) {
+        val fileIsEncrypted = psiFile.text.startsWith("\$ANSIBLE_VAULT")
+        val progressTitle = "${if (fileIsEncrypted) "Decrypting" else "Encrypting"} file(s) with ansible-vault"
+
+        if (fileIsEncrypted) {
+            progressManager.run(AnsibleVaultTask(
+                psiFile.project,
+                progressTitle,
+                DecryptFileAnsibleVaultRunnable(psiFile)
+            ))
+        } else {
+            if (!vaultIdentities.isNullOrEmpty()) {
+                AnsibleVaultIdentityPopup(vaultIdentities) {
+                    progressManager.run(AnsibleVaultTask(
+                        psiFile.project,
+                        progressTitle,
+                        EncryptFileAnsibleVaultRunnable(psiFile, it, false)
+                    ))
+                }.showCentered()
             } else {
-                val vaultIdentities = AnsibleConfigurationService.getInstance(psiFile.project)
-                    .getAggregatedConfig()
-                    .vaultIdentities
-
-                if (!vaultIdentities.isNullOrEmpty()) {
-                    AnsibleVaultIdentityPopup(vaultIdentities) {
-                        runTask(
-                            psiFile,
-                            title,
-                            EncryptFileAnsibleVaultRunnable(psiFile.project, psiFile, content, it, false)
-                        )
-                    }.showCentered()
-                } else {
-                    runTask(
-                        psiFile,
-                        title,
-                        EncryptFileAnsibleVaultRunnable(psiFile.project, psiFile, content, null, false)
-                    )
-                }
+                progressManager.run(AnsibleVaultTask(
+                    psiFile.project,
+                    progressTitle,
+                    EncryptFileAnsibleVaultRunnable(psiFile, null, false)
+                ))
             }
         }
     }
 
-    private fun runTask(psiFile: PsiFile, title: String, runnable: AnsibleVaultRunnable) {
-        val task = AnsibleVaultTask(
-            psiFile.project,
-            title,
-            runnable
-        )
-
-        ProgressManager.getInstance()
-            .run(task)
+    companion object {
+        const val NOTIFICATION_ERROR_TITLE = "Error"
+        const val NOTIFICATION_BINARIES_NOT_SUPPORTED = "Vaulting binary files not supported yet."
     }
 }
 

--- a/src/main/kotlin/de/timo_reymann/ansible_vault_integration/intention/menu/VaultFileMenuAction.kt
+++ b/src/main/kotlin/de/timo_reymann/ansible_vault_integration/intention/menu/VaultFileMenuAction.kt
@@ -27,27 +27,26 @@ open class VaultFileMenuAction : AnAction() {
 
         e.getData(LangDataKeys.VIRTUAL_FILE_ARRAY)?.forEach {
             val psiFile = psiManager.findFile(it) ?: return@forEach
-
-            if (psiFile is PsiBinaryFile) {
-                Notifications.Bus.notify(Notification(
-                    VaultFileMenuAction::class.java.canonicalName,
-                    NOTIFICATION_ERROR_TITLE,
-                    NOTIFICATION_BINARIES_NOT_SUPPORTED,
-                    NotificationType.ERROR
-                ))
-
-                return@forEach
-            }
-
-            if (psiFile.text.isNullOrEmpty()) {
-                return@forEach
-            }
-
             processFile(vaultIdentities, psiFile)
         }
     }
 
     private fun processFile(vaultIdentities: List<VaultIdentity>?, psiFile: PsiFile) {
+        if (psiFile is PsiBinaryFile) {
+            Notifications.Bus.notify(Notification(
+                VaultFileMenuAction::class.java.canonicalName,
+                NOTIFICATION_ERROR_TITLE,
+                NOTIFICATION_BINARIES_NOT_SUPPORTED,
+                NotificationType.ERROR
+            ))
+
+            return
+        }
+
+        if (psiFile.text.isNullOrEmpty()) {
+            return
+        }
+
         val fileIsEncrypted = psiFile.text.startsWith("\$ANSIBLE_VAULT")
         val progressTitle = "${if (fileIsEncrypted) "Decrypting" else "Encrypting"} file(s) with ansible-vault"
 

--- a/src/main/kotlin/de/timo_reymann/ansible_vault_integration/intention/menu/VaultFileMenuAction.kt
+++ b/src/main/kotlin/de/timo_reymann/ansible_vault_integration/intention/menu/VaultFileMenuAction.kt
@@ -5,55 +5,47 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.LangDataKeys
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
 import de.timo_reymann.ansible_vault_integration.config.AnsibleConfigurationService
 import de.timo_reymann.ansible_vault_integration.execution.AnsibleVaultTask
 import de.timo_reymann.ansible_vault_integration.intention.AnsibleVaultIdentityPopup
 import de.timo_reymann.ansible_vault_integration.runnable.AnsibleVaultRunnable
 import de.timo_reymann.ansible_vault_integration.runnable.DecryptFileAnsibleVaultRunnable
 import de.timo_reymann.ansible_vault_integration.runnable.EncryptFileAnsibleVaultRunnable
-import org.jetbrains.yaml.psi.YAMLFile
-import setVisible
 
 open class VaultFileMenuAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
-        val psiFile = e.getData(LangDataKeys.PSI_FILE) ?: return
-        val content = psiFile.text ?: return
-        val isVaulted = content.startsWith("\$ANSIBLE_VAULT")
-        val title = "${if (isVaulted) "Decrypt" else "Encrypt"} file with ansible-vault"
+        val project = e.project ?: return
+        e.getData(LangDataKeys.VIRTUAL_FILE_ARRAY)?.forEach {
+            val psiFile = PsiManager.getInstance(project).findFile(it) ?: return@forEach
+            val content = psiFile.text ?: return@forEach
+            val isVaulted = content.startsWith("\$ANSIBLE_VAULT")
+            val title = "${if (isVaulted) "Decrypt" else "Encrypt"} file(s) with ansible-vault"
 
-        if (isVaulted) {
-            runTask(psiFile, title, DecryptFileAnsibleVaultRunnable(psiFile.project, psiFile, content))
-        } else {
-            val vaultIdentities = AnsibleConfigurationService.getInstance(psiFile.project)
-                .getAggregatedConfig()
-                .vaultIdentities
+            if (isVaulted) {
+                runTask(psiFile, title, DecryptFileAnsibleVaultRunnable(psiFile.project, psiFile, content))
+            } else {
+                val vaultIdentities = AnsibleConfigurationService.getInstance(psiFile.project)
+                    .getAggregatedConfig()
+                    .vaultIdentities
 
-            if (vaultIdentities != null && vaultIdentities.isNotEmpty()) {
-                AnsibleVaultIdentityPopup(vaultIdentities) {
+                if (!vaultIdentities.isNullOrEmpty()) {
+                    AnsibleVaultIdentityPopup(vaultIdentities) {
+                        runTask(
+                            psiFile,
+                            title,
+                            EncryptFileAnsibleVaultRunnable(psiFile.project, psiFile, content, it, false)
+                        )
+                    }.showCentered()
+                } else {
                     runTask(
                         psiFile,
                         title,
-                        EncryptFileAnsibleVaultRunnable(psiFile.project, psiFile, content, it, false)
+                        EncryptFileAnsibleVaultRunnable(psiFile.project, psiFile, content, null, false)
                     )
-                }.showCentered()
-            } else {
-                runTask(
-                    psiFile,
-                    title,
-                    EncryptFileAnsibleVaultRunnable(psiFile.project, psiFile, content, null, false)
-                )
+                }
             }
         }
-    }
-
-    override fun update(e: AnActionEvent) {
-        val file = e.getData(LangDataKeys.PSI_FILE) ?: return
-        if (file !is YAMLFile) {
-            e.setVisible(false)
-            return
-        }
-
-        e.setVisible(true)
     }
 
     private fun runTask(psiFile: PsiFile, title: String, runnable: AnsibleVaultRunnable) {

--- a/src/main/kotlin/de/timo_reymann/ansible_vault_integration/runnable/DecryptFileAnsibleVaultRunnable.kt
+++ b/src/main/kotlin/de/timo_reymann/ansible_vault_integration/runnable/DecryptFileAnsibleVaultRunnable.kt
@@ -2,21 +2,22 @@ package de.timo_reymann.ansible_vault_integration.runnable
 
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
-import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import de.timo_reymann.ansible_vault_integration.execution.action.AnsibleVaultDecryptAction
 import de.timo_reymann.ansible_vault_integration.util.AnsibleVaultedStringUtil
 
 class DecryptFileAnsibleVaultRunnable(
-    private val project: Project,
-    private val containingFile: PsiFile,
-    private val raw: String
+    private val containingFile: PsiFile
 ) : AnsibleVaultRunnable {
     @Throws(Exception::class)
     override fun run() {
-        val decrypted = AnsibleVaultDecryptAction(project, containingFile, AnsibleVaultedStringUtil.addPrefix(raw))
-            .execute()
-        WriteCommandAction.runWriteCommandAction(project) {
+        val decrypted = AnsibleVaultDecryptAction(
+            containingFile.project,
+            containingFile,
+            AnsibleVaultedStringUtil.addPrefix(containingFile.text)
+        ).execute()
+
+        WriteCommandAction.runWriteCommandAction(containingFile.project) {
             FileDocumentManager.getInstance()
                 .getDocument(containingFile.virtualFile)?.setText(decrypted)
         }

--- a/src/main/kotlin/de/timo_reymann/ansible_vault_integration/runnable/EncryptFileAnsibleVaultRunnable.kt
+++ b/src/main/kotlin/de/timo_reymann/ansible_vault_integration/runnable/EncryptFileAnsibleVaultRunnable.kt
@@ -25,5 +25,5 @@ class EncryptFileAnsibleVaultRunnable(
     }
 
     override val successMessage: String
-        get() = "File vaulted"
+        get() = "File encrypted"
 }

--- a/src/main/kotlin/de/timo_reymann/ansible_vault_integration/runnable/EncryptFileAnsibleVaultRunnable.kt
+++ b/src/main/kotlin/de/timo_reymann/ansible_vault_integration/runnable/EncryptFileAnsibleVaultRunnable.kt
@@ -2,23 +2,26 @@ package de.timo_reymann.ansible_vault_integration.runnable
 
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
-import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import de.timo_reymann.ansible_vault_integration.config.VaultIdentity
 import de.timo_reymann.ansible_vault_integration.execution.action.AnsibleVaultEncryptAction
 
 class EncryptFileAnsibleVaultRunnable(
-    private val project: Project,
     private val containingFile: PsiFile,
-    private val content: String,
     private val vaultIdentity: VaultIdentity?,
     private val addPrefix: Boolean = true
 ) : AnsibleVaultRunnable {
     @Throws(Exception::class)
     override fun run() {
-        val encrypted = AnsibleVaultEncryptAction(project, containingFile, content, vaultIdentity, addPrefix)
-            .execute()
-        WriteCommandAction.runWriteCommandAction(project) {
+        val encrypted = AnsibleVaultEncryptAction(
+            containingFile.project,
+            containingFile,
+            containingFile.text,
+            vaultIdentity,
+            addPrefix
+        ).execute()
+
+        WriteCommandAction.runWriteCommandAction(containingFile.project) {
             FileDocumentManager.getInstance()
                 .getDocument(containingFile.virtualFile)?.setText(encrypted)
         }

--- a/src/main/kotlin/de/timo_reymann/ansible_vault_integration/runnable/EncryptStringAnsibleVaultRunnable.kt
+++ b/src/main/kotlin/de/timo_reymann/ansible_vault_integration/runnable/EncryptStringAnsibleVaultRunnable.kt
@@ -33,5 +33,5 @@ class EncryptStringAnsibleVaultRunnable(
     }
 
     override val successMessage: String
-        get() = "String vaulted and replaced"
+        get() = "String encrypted and replaced"
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -136,8 +136,8 @@
     <actions>
         <action id="de.timo_reymann.ansible_vault_integration.execution.action.action.menu.VaultFileMenuAction"
                 class="de.timo_reymann.ansible_vault_integration.intention.menu.VaultFileMenuAction"
-                text="Vault/Unvault File"
-                description="Encrypt/Decrypt the given file using ansible-vault">
+                text="Vault/Unvault File(s)"
+                description="Encrypt/Decrypt the given file(s) using ansible-vault">
             <add-to-group group-id="CutCopyPasteGroup" anchor="last"/>
         </action>
     </actions>


### PR DESCRIPTION
Howdy Timo,

it's me again... :smile:

I'd like to propose a few additional changes/updates.

* support context-/file-action for multiple files  
  (at the moment only one file can be encrypted/decrypted at a time; but I often want/need to alter several files in one go)
* remove file type limitation for vault-action;  
  (I don't see a good reason why vaulting should be limites to YAML files only; vaulted content is transparent and can be used on any file)
* consistent usage of "vault / unvault" and "encrypt / decrypt" wording;  
  (see changes)

I hope all of this makes sense.

Again... thanks for your efforts!