### PR TITLE
chore: print a more portable bash command via /usr/bin/env

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Cli args:
 Create the file `.idea-get-vault-password.sh` (0700):
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Helper to show error message
 __error_message() {


### PR DESCRIPTION
This change is generally considered to be more portable, as some users have more bash versions installed

More info: https://stackoverflow.com/a/21613044/109305

