### PR TITLE
add missing key for 'projectConfigurable'; add 'messages' resourceBundle

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -149,6 +149,7 @@
         <!-- Configuration -->
         <projectConfigurable id="de.timo_reymann.ansible_vault_integration.settings.AnsibleVaultSettings"
                              groupId="tools"
+                             key="settings.display_name"
                              instance="de.timo_reymann.ansible_vault_integration.settings.AnsibleVaultSettingsConfigurable"/>
         <projectService
                 serviceImplementation="de.timo_reymann.ansible_vault_integration.settings.AnsibleVaultSettings"/>
@@ -163,4 +164,5 @@
             <add-to-group group-id="CutCopyPasteGroup" anchor="last"/>
         </action>
     </actions>
+    <resource-bundle>messages.AnsibleVaultIntegrationBundle</resource-bundle>
 </idea-plugin>


### PR DESCRIPTION
Hey there,

recent versions of IntelliJ throw this exception:

```
com.intellij.diagnostic.PluginException: No display name specified in plugin descriptor XML file for configurable de.timo_reymann.ansible_vault_integration.settings.AnsibleVaultSettingsConfigurable;
specify it using 'displayName' or 'key' attribute to avoid necessity to load the configurable class when Settings dialog is opened [Plugin: com.github.timo_reymann.ansible_vault_integration]
	at com.intellij.openapi.options.ex.ConfigurableWrapper.getDisplayName(ConfigurableWrapper.java:156)
	at com.intellij.openapi.options.ex.Weighted.lambda$static$0(Weighted.java:26)
	at java.base/java.util.TimSort.binarySort(TimSort.java:296)
	at java.base/java.util.TimSort.sort(TimSort.java:221)
	at java.base/java.util.Arrays.sort(Arrays.java:1307)
	at java.base/java.util.ArrayList.sort(ArrayList.java:1721)
	at com.intellij.openapi.options.ex.SortedConfigurableGroup.buildConfigurables(SortedConfigurableGroup.java:41)
	at com.intellij.openapi.options.SearchableConfigurable$Parent$Abstract.getConfigurables(SearchableConfigurable.java:75)
	at com.intellij.openapi.options.ex.EpBasedConfigurableGroupKt.collect(EpBasedConfigurableGroup.kt:148)
	at com.intellij.openapi.options.ex.EpBasedConfigurableGroupKt.access$collect(EpBasedConfigurableGroup.kt:1)
```

I've had the same issue with my own plugin(s), e.g. [github-markdown-emojis ](https://github.com/4ch1m/github-markdown-emojis/issues/4) :smile:

This PR will fix it.